### PR TITLE
Update Go version of builder to support modules and pin spruce to v1.…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apk add --no-cache --no-progress \
     libc-dev \
     upx
 
-RUN go get github.com/geofffranks/spruce/cmd/spruce@v1.29.0 && chmod +x /go/bin/spruce
+RUN go install github.com/geofffranks/spruce/cmd/spruce@v1.29.0 && chmod +x /go/bin/spruce
 COPY . .
 #RUN make test release
 RUN make release

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.15-alpine as builder
+FROM docker.io/library/golang:1.16-alpine as builder
 
 MAINTAINER Jack Murdock <jack_murdock@comcast.com>
 
@@ -18,7 +18,7 @@ RUN apk add --no-cache --no-progress \
     libc-dev \
     upx
 
-RUN go get github.com/geofffranks/spruce/cmd/spruce && chmod +x /go/bin/spruce
+RUN go get github.com/geofffranks/spruce/cmd/spruce@v1.29.0 && chmod +x /go/bin/spruce
 COPY . .
 #RUN make test release
 RUN make release

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.16-alpine as builder
+FROM docker.io/library/golang:1.18-alpine as builder
 
 MAINTAINER Jack Murdock <jack_murdock@comcast.com>
 


### PR DESCRIPTION
Docker build fails:

```
daniel@computer themis ➜ git:(general-usable-jwks) docker build --no-cache -t themis:local .
Sending build context to Docker daemon  2.328MB
Step 1/22 : FROM docker.io/library/golang:1.15-alpine as builder
 ---> 1403af3b6d4a
Step 2/22 : MAINTAINER Jack Murdock <jack_murdock@comcast.com>
 ---> Running in 45a5579e0dcf
Removing intermediate container 45a5579e0dcf
 ---> d34fc739579c
Step 3/22 : WORKDIR /src
 ---> Running in c05d3a530886
Removing intermediate container c05d3a530886
 ---> 254a417c7233
Step 4/22 : ARG VERSION
 ---> Running in f704c1324b81
Removing intermediate container f704c1324b81
 ---> 7c867ae056ef
Step 5/22 : ARG GITCOMMIT
 ---> Running in 818e756d26e6
Removing intermediate container 818e756d26e6
 ---> c4b5f6b3b8d2
Step 6/22 : ARG BUILDTIME
 ---> Running in 98633cad644c
Removing intermediate container 98633cad644c
 ---> 8beaa09d1d03
Step 7/22 : RUN apk add --no-cache --no-progress     ca-certificates     make     git     openssh     gcc     libc-dev     upx
 ---> Running in d90153a0580a
fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/community/x86_64/APKINDEX.tar.gz
(1/32) Installing libgcc (10.3.1_git20210424-r2)
(2/32) Installing libstdc++ (10.3.1_git20210424-r2)
(3/32) Installing binutils (2.35.2-r2)
(4/32) Installing libgomp (10.3.1_git20210424-r2)
(5/32) Installing libatomic (10.3.1_git20210424-r2)
(6/32) Installing libgphobos (10.3.1_git20210424-r2)
(7/32) Installing gmp (6.2.1-r1)
(8/32) Installing isl22 (0.22-r0)
(9/32) Installing mpfr4 (4.1.0-r0)
(10/32) Installing mpc1 (1.2.1-r0)
(11/32) Installing gcc (10.3.1_git20210424-r2)
(12/32) Installing brotli-libs (1.0.9-r5)
(13/32) Installing nghttp2-libs (1.43.0-r0)
(14/32) Installing libcurl (7.79.1-r4)
(15/32) Installing expat (2.5.0-r0)
(16/32) Installing pcre2 (10.36-r1)
(17/32) Installing git (2.32.4-r0)
(18/32) Installing musl-dev (1.2.2-r3)
(19/32) Installing libc-dev (0.7.2-r3)
(20/32) Installing make (4.3-r0)
(21/32) Installing openssh-keygen (8.6_p1-r3)
(22/32) Installing ncurses-terminfo-base (6.2_p20210612-r1)
(23/32) Installing ncurses-libs (6.2_p20210612-r1)
(24/32) Installing libedit (20210216.3.1-r0)
(25/32) Installing openssh-client-common (8.6_p1-r3)
(26/32) Installing openssh-client-default (8.6_p1-r3)
(27/32) Installing openssh-sftp-server (8.6_p1-r3)
(28/32) Installing openssh-server-common (8.6_p1-r3)
(29/32) Installing openssh-server (8.6_p1-r3)
(30/32) Installing openssh (8.6_p1-r3)
(31/32) Installing ucl (1.03-r1)
(32/32) Installing upx (3.96-r1)
Executing busybox-1.33.1-r3.trigger
OK: 148 MiB in 47 packages
Removing intermediate container d90153a0580a
 ---> 7d0be3b1c6f9
Step 8/22 : RUN go get github.com/geofffranks/spruce/cmd/spruce && chmod +x /go/bin/spruce
 ---> Running in 4f6196136d9e
# github.com/geofffranks/spruce/vendor/golang.org/x/sys/unix
/go/src/github.com/geofffranks/spruce/vendor/golang.org/x/sys/unix/syscall.go:83:16: undefined: unsafe.Slice
/go/src/github.com/geofffranks/spruce/vendor/golang.org/x/sys/unix/syscall_linux.go:2256:9: undefined: unsafe.Slice
/go/src/github.com/geofffranks/spruce/vendor/golang.org/x/sys/unix/syscall_unix.go:118:7: undefined: unsafe.Slice
/go/src/github.com/geofffranks/spruce/vendor/golang.org/x/sys/unix/sysvshm_unix.go:33:7: undefined: unsafe.Slice
The command '/bin/sh -c go get github.com/geofffranks/spruce/cmd/spruce && chmod +x /go/bin/spruce' returned a non-zero code: 2
```